### PR TITLE
Refactor: Remove default node authentication and update node types

### DIFF
--- a/p2p/config.go
+++ b/p2p/config.go
@@ -8,7 +8,6 @@ import (
 
 // Config representa la configuración del nodo semilla
 type Config struct {
-	InitialNodes        []string     `json:"initialNodes"`        // Lista inicial de nodos conocidos
 	MaxNodes            int          `json:"maxNodes"`            // Número máximo de nodos a almacenar
 	ConfigFile          string       `json:"configFile"`          // Ruta al archivo de configuración
 	DBPath              string       `json:"dbPath"`              // Ruta al directorio de la base de datos
@@ -21,7 +20,6 @@ type Config struct {
 // NewConfig crea una nueva configuración con valores por defecto
 func NewConfig(configFile string) *Config {
 	config := &Config{
-		InitialNodes:        []string{},
 		MaxNodes:            100, // Valor por defecto
 		ConfigFile:          configFile,
 		DBPath:              "data/leveldb", // Directorio por defecto para LevelDB
@@ -75,25 +73,6 @@ func (c *Config) Save() error {
 	encoder := json.NewEncoder(file)
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(c)
-}
-
-// GetInitialNodes devuelve una copia de los nodos iniciales
-func (c *Config) GetInitialNodes() []string {
-	c.mutex.RLock()
-	defer c.mutex.RUnlock()
-
-	nodes := make([]string, len(c.InitialNodes))
-	copy(nodes, c.InitialNodes)
-	return nodes
-}
-
-// SetInitialNodes establece los nodos iniciales
-func (c *Config) SetInitialNodes(nodes []string) {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
-	c.InitialNodes = make([]string, len(nodes))
-	copy(c.InitialNodes, nodes)
 }
 
 // GetMaxNodes devuelve el número máximo de nodos

--- a/p2p/node_manager.go
+++ b/p2p/node_manager.go
@@ -40,11 +40,6 @@ func NewNodeManager(config *Config, storage *DBStorage, logger *log.Logger) *Nod
 		nm.loadNodesFromStorage()
 	}
 
-	// Añadir nodos iniciales de la configuración si no existen ya
-	for _, node := range config.GetInitialNodes() {
-		nm.AddNode(node, RegularNode) // Asignar tipo por defecto para nodos iniciales
-	}
-
 	return nm
 }
 

--- a/p2p/types.go
+++ b/p2p/types.go
@@ -5,6 +5,6 @@ type NodeType string
 const (
 	SeedsNode     NodeType = "seed"
 	ValidatorNode NodeType = "validator"
-	RegularNode   NodeType = "regular"
+	FullNode      NodeType = "full"
 	APINode       NodeType = "api"
 )


### PR DESCRIPTION
- I removed the logic that automatically authenticated default seed nodes on startup. Nodes are now expected to be added dynamically.
- I updated the NodeType definition in `p2p/types.go`: `RegularNode` ("regular") was changed to `FullNode` ("full") to align with specified requirements.
- I removed the `InitialNodes` configuration from `p2p/config.go` and its associated getter/setter as it's no longer used by the `NodeManager`.
- I ensured `NodeManager` in `p2p/node_manager.go` no longer loads initial nodes from the configuration. The `AddNode` function already supports dynamic addition with specified node types.